### PR TITLE
fix: allow excluding accessor methods

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -137,10 +137,10 @@ export function promisifyAll(Class: Function, options?: PromisifyAllOptions) {
   const methods = ownPropertyNames.filter(methodName => {
     // clang-format off
     return (
+      !exclude.includes(methodName) &&
       typeof Class.prototype[methodName] === 'function' && // is it a function?
-      !/(^_|(Stream|_)|promise$)|^constructor$/.test(methodName) && // is it promisable?
-      exclude.indexOf(methodName) === -1
-    ); // is it blacklisted?
+      !/(^_|(Stream|_)|promise$)|^constructor$/.test(methodName) // is it promisable?
+    );
     // clang-format on
   });
 
@@ -203,10 +203,10 @@ export function callbackifyAll(
   const methods = ownPropertyNames.filter(methodName => {
     // clang-format off
     return (
+      !exclude.includes(methodName) &&
       typeof Class.prototype[methodName] === 'function' && // is it a function?
-      !/^_|(Stream|_)|^constructor$/.test(methodName) && // is it callbackifyable?
-      exclude.indexOf(methodName) === -1
-    ); // is it blacklisted?
+      !/^_|(Stream|_)|^constructor$/.test(methodName) // is it callbackifyable?
+    );
     // clang-format on
   });
 

--- a/test/index.ts
+++ b/test/index.ts
@@ -103,6 +103,7 @@ describe('promisifyAll', () => {
     Object.defineProperty(FakeClass2.prototype, 'method', {
       get: () => {
         done(new Error('Accessor method should not be called.'));
+        return {};
       },
     });
     assert.doesNotThrow(() => {
@@ -315,6 +316,7 @@ describe('callbackifyAll', () => {
     Object.defineProperty(FakeClass2.prototype, 'method', {
       get: () => {
         done(new Error('Accessor method should not be called.'));
+        return {};
       },
     });
     assert.doesNotThrow(() => {

--- a/test/index.ts
+++ b/test/index.ts
@@ -98,6 +98,21 @@ describe('promisifyAll', () => {
     assert(FakeClass2.prototype.method.promisified_);
   });
 
+  it('should honor excluded properties first', done => {
+    function FakeClass2() {}
+    Object.defineProperty(FakeClass2.prototype, 'method', {
+      get: () => {
+        done(new Error('Accessor method should not be called.'));
+      },
+    });
+    assert.doesNotThrow(() => {
+      util.promisifyAll(FakeClass2, {
+        exclude: ['method'],
+      });
+      done();
+    });
+  });
+
   it('should pass the options object to promisify', done => {
     const fakeOptions = {
       a: 'a',
@@ -293,6 +308,21 @@ describe('callbackifyAll', () => {
     assert.strictEqual(FakeClass2.prototype.methodSync, noop);
     assert(FakeClass2.prototype.method.callbackified_);
     assert.strictEqual(FakeClass2.prototype.methodSync, noop);
+  });
+
+  it('should honor excluded properties first', done => {
+    function FakeClass2() {}
+    Object.defineProperty(FakeClass2.prototype, 'method', {
+      get: () => {
+        done(new Error('Accessor method should not be called.'));
+      },
+    });
+    assert.doesNotThrow(() => {
+      util.callbackifyAll(FakeClass2, {
+        exclude: ['method'],
+      });
+      done();
+    });
   });
 
   it('should not re-callbackify method', () => {


### PR DESCRIPTION
While working on https://github.com/googleapis/nodejs-bigtable/pull/794, I noticed some accessor methods were being unexpectedly called by this module, even though they were excluded. Example:

```js
class Backup {
  // ...
  get expireDate() {
    throw new Error('Should not be called')
  }
}

// ...

promisifyAll(Backup, { exclude: ['expireDate'] });
// throws "Should not be called"
```

This is because of the ordering which this module checks what methods from a prototype should be excluded:

  1. Is it a function?
  2. Is it a stream, or the constructor? Something that can't be promsified?
  3. Was it in the "exclude" array?

In this case, step 1 was what caused the error:

```js
typeof Backup.prototype.expireDate
// throws "Should not be called"
```

The easiest way to solve this seemed to be to just bump step 3 up to step 1-- if the user wants it excluded, why do any other guessing?